### PR TITLE
Adding weights_only param to allow loading of unusual model params

### DIFF
--- a/docs/guide/save_format.rst
+++ b/docs/guide/save_format.rst
@@ -24,6 +24,11 @@ A zip-archived JSON dump, PyTorch state dictionaries and PyTorch variables. The 
 is stored as a JSON file, model parameters and optimizers are serialized with ``torch.save()`` function and these files
 are stored under a single .zip archive.
 
+Note that if you use unsafe objects in your torch model, ``torch.load()`` will raise an unpickling error.  You can
+use the "weights_only" argument to adjust whether or not to load unsafe objects using Pickle, but it will issue 
+a warning if set to False.  (e.g.: if learning_rate_schedule contains the scalar np.pi, it will raise an error without
+the "weights_only" argument set to False)
+
 Any objects that are not JSON serializable are serialized with cloudpickle and stored as base64-encoded
 string in the JSON file, along with some information that was stored in the serialization. This allows
 inspecting stored objects without deserializing the object itself.

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -38,6 +38,7 @@ Breaking Changes:
 
 - For safety, ``torch.load()`` is now called with ``weights_only=True`` when loading torch tensors,
   policy ``load()`` still uses ``weights_only=False`` as gymnasium imports are required for it to work
+  This can be overriden using the ``weights_only`` boolean argument in the ``load()`` method in sb3, which will be passed to ``torch.load()``
 - When using ``huggingface_sb3``, you will now need to set ``TRUST_REMOTE_CODE=True`` when downloading models from the hub, as ``pickle.load`` is not safe.
 
 

--- a/stable_baselines3/common/base_class.py
+++ b/stable_baselines3/common/base_class.py
@@ -575,6 +575,7 @@ class BaseAlgorithm(ABC):
         load_path_or_dict: Union[str, TensorDict],
         exact_match: bool = True,
         device: Union[th.device, str] = "auto",
+        weights_only: bool = True,
     ) -> None:
         """
         Load parameters from a given zip-file or a nested dictionary containing parameters for
@@ -587,12 +588,15 @@ class BaseAlgorithm(ABC):
             module and each of their parameters, otherwise raises an Exception. If set to False, this
             can be used to update only specific parameters.
         :param device: Device on which the code should run.
+        :param weights_only: Set torch weights_only for passthrough into load function.
+            WARNING: weights_only=True to avoid posisble arbitrary code execution!
+            See https://pytorch.org/docs/stable/generated/torch.load.html
         """
         params = {}
         if isinstance(load_path_or_dict, dict):
             params = load_path_or_dict
         else:
-            _, params, _ = load_from_zip_file(load_path_or_dict, device=device)
+            _, params, _ = load_from_zip_file(load_path_or_dict, device=device, weights_only=weights_only)
 
         # Keep track which objects were updated.
         # `_get_torch_save_params` returns [params, other_pytorch_variables].
@@ -647,6 +651,7 @@ class BaseAlgorithm(ABC):
         custom_objects: Optional[Dict[str, Any]] = None,
         print_system_info: bool = False,
         force_reset: bool = True,
+        weights_only: bool = True,
         **kwargs,
     ) -> SelfBaseAlgorithm:
         """
@@ -670,6 +675,9 @@ class BaseAlgorithm(ABC):
         :param force_reset: Force call to ``reset()`` before training
             to avoid unexpected behavior.
             See https://github.com/DLR-RM/stable-baselines3/issues/597
+        :param weights_only: Set torch weights_only for passthrough into load function.
+            WARNING: weights_only=True to avoid posisble arbitrary code execution!
+            See https://pytorch.org/docs/stable/generated/torch.load.html
         :param kwargs: extra arguments to change the model when loading
         :return: new model instance with loaded parameters
         """
@@ -678,10 +686,7 @@ class BaseAlgorithm(ABC):
             get_system_info()
 
         data, params, pytorch_variables = load_from_zip_file(
-            path,
-            device=device,
-            custom_objects=custom_objects,
-            print_system_info=print_system_info,
+            path, device=device, custom_objects=custom_objects, print_system_info=print_system_info, weights_only=weights_only
         )
 
         assert data is not None, "No data found in the saved file"

--- a/stable_baselines3/common/save_util.py
+++ b/stable_baselines3/common/save_util.py
@@ -430,7 +430,10 @@ def load_from_zip_file(
                         "The model was saved with SB3 <= 1.2.0 and thus cannot print system information.",
                         UserWarning,
                     )
-
+            if weights_only is False:
+                        warnings.warn(
+                            "Unpickling unsafe objects! Loading full state_dict. See pytorch docs on torch.load for more info."
+                        )
             if "data" in namelist and load_data:
                 # Load class parameters that are stored
                 # with either JSON or pickle (not PyTorch variables).
@@ -451,10 +454,6 @@ def load_from_zip_file(
                     file_content.seek(0)
                     # Load the parameters with the right ``map_location``.
                     # Remove ".pth" ending with splitext
-                    if weights_only is False:
-                        warnings.warn(
-                            f"Unpickling unsafe objects! Loading full state_dict from {file_path}. See pytorch docs on torch.load for more info."
-                        )
                     th_object = th.load(file_content, map_location=device, weights_only=weights_only)
                     # "tensors.pth" was renamed "pytorch_variables.pth" in v0.9.0, see PR #138
                     if file_path == "pytorch_variables.pth" or file_path == "tensors.pth":

--- a/stable_baselines3/common/save_util.py
+++ b/stable_baselines3/common/save_util.py
@@ -431,9 +431,9 @@ def load_from_zip_file(
                         UserWarning,
                     )
             if weights_only is False:
-                        warnings.warn(
-                            "Unpickling unsafe objects! Loading full state_dict. See pytorch docs on torch.load for more info."
-                        )
+                warnings.warn(
+                    "Unpickling unsafe objects! Loading full state_dict. See pytorch docs on torch.load for more info."
+                )
             if "data" in namelist and load_data:
                 # Load class parameters that are stored
                 # with either JSON or pickle (not PyTorch variables).

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from copy import deepcopy
 
 import gymnasium as gym
+from gymnasium.spaces import Box, Discrete
 import numpy as np
 import pytest
 import torch as th
@@ -742,12 +743,19 @@ def test_load_torch_weights_only(tmp_path):
     # Test loading only the torch weights
     path = str(tmp_path / "ppo_pendulum.zip")
     model = PPO("MlpPolicy", "Pendulum-v1", learning_rate=lambda _: 1.0)
-    model.learn(1)
+    model.learn(10)
     model.save(path)
     # Load with custom object, no warnings
     with warnings.catch_warnings(record=True) as record:
         model.load(path, custom_objects=dict(learning_rate=lambda _: 1.0), weights_only=False)
     assert len(record) == 1
+
+    # Load only the weights from a valid model
+    with warnings.catch_warnings(record=True) as record:
+        model.load(path, weights_only=True)
+    assert len(record) == 0
+
+    # TODO: Negative test case.  I can cause this to fail with a saved model.  Need to understand how / why.
 
 def test_dqn_target_update_interval(tmp_path):
     # `target_update_interval` should not change when reloading the model. See GH Issue #1373.

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -738,6 +738,16 @@ def test_load_invalid_object(tmp_path):
         PPO.load(path, custom_objects=dict(learning_rate=lambda _: 1.0))
     assert len(record) == 0
 
+def test_load_torch_weights_only(tmp_path):
+    # Test loading only the torch weights
+    path = str(tmp_path / "ppo_pendulum.zip")
+    model = PPO("MlpPolicy", "Pendulum-v1", learning_rate=lambda _: 1.0)
+    model.learn(1)
+    model.save(path)
+    # Load with custom object, no warnings
+    with warnings.catch_warnings(record=True) as record:
+        model.load(path, custom_objects=dict(learning_rate=lambda _: 1.0), weights_only=False)
+    assert len(record) == 1
 
 def test_dqn_target_update_interval(tmp_path):
     # `target_update_interval` should not change when reloading the model. See GH Issue #1373.

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,19 +1,17 @@
 import base64
 import io
 import json
-import os
 import math
-import pickle
+import os
 import pathlib
+import pickle
 import tempfile
 import warnings
 import zipfile
-
 from collections import OrderedDict
 from copy import deepcopy
 
 import gymnasium as gym
-from gymnasium.spaces import Box, Discrete
 import numpy as np
 import pytest
 import torch as th
@@ -776,8 +774,10 @@ def test_load_torch_weights_only(tmp_path):
         model.load(path, weights_only=True)
     assert len(record) == 0
 
-    # Causes pickle error due to numpy scalars in the learning rate schedule
-    # _pickle.UnpicklingError: Weights only load failed. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution.Do it only if you get the file from a trusted source. WeightsUnpickler error: Unsupported class numpy.core.multiarray.scalar
+    # Causes pickle error due to numpy scalars in the learning rate schedule:
+    # _pickle.UnpicklingError: Weights only load failed. Re-running `torch.load` with `weights_only` set to `False`
+    # will likely succeed, but it can result in arbitrary code execution.Do it only if you get the file from a
+    # trusted source. WeightsUnpickler error: Unsupported class numpy.core.multiarray.scalar
     def learning_rate_schedule(progress):
         rate = 0.0003
         variation = 0.2 * rate * progress


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When using stable_baselines3, it is possible to specify a learning_rate_schedule that is a function rather than a static number.  If this function contains numpy scalars (e.g.: ```np.pi```) these scalars will cause the model to fail to load with weights_only=True because the numpy scalars are not a supported type.

## Description
<!--- Describe your changes in detail -->
The primary change is a "weights_only" parameter for the load function, allowing the user to change the weights_only parameter as needed when loading models of this type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is to address an edge case around learning_rate_schedule being a function and also using data types that are not marked safe as part of torch.load

<!--- If it fixes an open issue, please link to the issue here. -->
Related to enhancement https://github.com/DLR-RM/stable-baselines3/issues/1852

<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the changelog accordingly (**required**).
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [X] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [X] I have ensured `make pytest` and `make type` both pass. (**required**)
- [X] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
